### PR TITLE
Prevent users from linking closed tickets

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,13 +111,21 @@
       }
     },
 
+    ticketIsClosed: function() {
+      return this.ticket().status() == "closed";
+    },
+
     displayHome: function(){
       this.switchTo('home', {
-        closed_warn: this.ticket().status() == "closed"
+        closed_warn: this.ticketIsClosed()
       });
     },
 
     displayForm: function(event){
+      if(this.ticketIsClosed()) {
+        return;
+      }
+
       event.preventDefault();
 
       this.paginateRequest('fetchGroups').then(function(data){
@@ -128,7 +136,7 @@
         current_user: {
           email: this.currentUser().email()
         },
-        closed_warn: this.ticket().status() == "closed",
+        closed_warn: this.ticketIsClosed(),
         tags: this.tags(),
         ccs: this.ccs()
       });
@@ -308,7 +316,7 @@
 
       var parent_closed = false;
 
-      if(this.ticket().status() == "closed") {
+      if(this.ticketIsClosed()) {
         parent_closed = true;
       }
 

--- a/templates/home.hdbs
+++ b/templates/home.hdbs
@@ -3,6 +3,9 @@
 {{/if}}
 <div class="well">
   <div class="row-fluid centered">
-    <a class="new-linked-ticket btn btn-success btn-large">{{t "create_ticket"}}</a>
+    <a class="new-linked-ticket btn btn-success btn-large"
+       {{#if closed_warn}}disabled="disabled"{{/if}}>
+      {{t "create_ticket"}}
+    </a>
   </div>
 </div>

--- a/translations/en.json
+++ b/translations/en.json
@@ -232,6 +232,6 @@
   },
   "closed_warn": {
     "title": "A warning that the current ticket is closed and cannot reference the child",
-    "value": "This ticket is closed and cannot be modified. Only the child ticket will continue to contain a reference"
+    "value": "This ticket is closed and cannot be linked."
   }
 }


### PR DESCRIPTION
@itirkarp and I double checked with @alieu that people shouldn't be able to link closed tickets, although maybe @maximeprades wants to weigh in.

This was causing problems previously where it'd create a child ticket of a closed ticket but then not actually store the reference on the closed (i.e. parent) ticket because you can't modify the fields of closed tickets.

This required a translation change too.

/cc @zendesk/quokka 

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-324

### Risks
 - None