### PR TITLE
Create custom ticket field using requirements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2015-02-04 Alistair Roche <aroche@zendesk.com>
+    * Use Apps Requirements to create custom ticket field
 2013-02-15 Pierre Nespo <pierre.nespo@gmail.com>
 	* Bump to v1.0: Major change is the modification of the parameter name (from data_field to ancestry_field)
 2013-03-07 Pierre Nespo <pierre.nespo@gmail.com>

--- a/app.js
+++ b/app.js
@@ -556,7 +556,7 @@
       return this.ticket().customField("custom_field_" + this.ancestryFieldId());
     },
     ancestryFieldId: function(){
-      return this.setting('ancestry_field');
+      return this.requirement('linked_ticket_id').requirement_id;
     },
     hasChild: function(){
       return this.parentRegex.test(this.ancestryValue());

--- a/manifest.json
+++ b/manifest.json
@@ -7,11 +7,6 @@
 
   "parameters": [
     {
-      "name": "ancestry_field",
-      "type": "text",
-      "required": true
-    },
-    {
       "name": "child_tag",
       "type": "text"
     }

--- a/requirements.json
+++ b/requirements.json
@@ -1,0 +1,8 @@
+{
+  "ticket_fields": {
+    "linked_ticket_id": {
+      "type": "text",
+      "title": "Linked Ticket ID"
+    }
+  }
+}


### PR DESCRIPTION
Rather than having to be all like “hey go create a custom ticket field to do some stuff” we now don't have to.

Warning 1: enterprise customers will have to add it to a ticket form, just like they currently do (this doesn't remove that issue)
Warning 2: people who upgrade from the old one to the new one will not have their linked tickets being linked any more (this is the same as with the new requirements version of the time tracking app).

Also @itirkarp was here too and we tried to use hitch but it didn't work =(

/cc @zendesk/quokka 

### References
 - Jira link:

### Risks
 - None