### PR TITLE
[OFFAPPS-515] Don't enable submit, clicking quickly allows creation of duplicate linked tickets

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,9 +154,11 @@
         this.disableSubmit();
 
         this.ajax('createChildTicket', attributes)
+          .fail(function(){
+            this.enableSubmit();
+          })
           .always(function(){
             this.spinnerOff();
-            this.enableSubmit();
           });
       }
     },


### PR DESCRIPTION
The create button was being enabled for a second after creating a linked ticket and if you clicked on it quickly it would create another ticket.
There is no need to enable it, the button disappears anyway after a linked ticket is created.

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-515

### Risks
 - None