### PR TITLE
[OFFAPPS-516] Display a forbidden message if there is already a linked ticket that the user can't see

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,9 +115,10 @@
       return this.ticket().status() == "closed";
     },
 
-    displayHome: function(){
+    displayHome: function(data){
       this.switchTo('home', {
-        closed_warn: this.ticketIsClosed()
+        closed_warn: this.ticketIsClosed(),
+        forbidden: data && data.status === 403
       });
     },
 

--- a/templates/home.hdbs
+++ b/templates/home.hdbs
@@ -1,11 +1,19 @@
-{{#if closed_warn}}
-  <div class="alert alert-danger">{{t "closed_warn"}}</div>
-{{/if}}
-<div class="well">
-  <div class="row-fluid centered">
-    <a class="new-linked-ticket btn btn-success btn-large"
-       {{#if closed_warn}}disabled="disabled"{{/if}}>
-      {{t "create_ticket"}}
-    </a>
+{{#if forbidden}}
+  <div class="well">
+    <div class="row-fluid centered">
+      {{t "forbidden"}}
+    </div>
   </div>
-</div>
+{{else}}
+  {{#if closed_warn}}
+    <div class="alert alert-danger">{{t "closed_warn"}}</div>
+  {{/if}}
+  <div class="well">
+    <div class="row-fluid centered">
+      <a class="new-linked-ticket btn btn-success btn-large"
+         {{#if closed_warn}}disabled="disabled"{{/if}}>
+        {{t "create_ticket"}}
+      </a>
+    </div>
+  </div>
+{{/if}}

--- a/translations/en.json
+++ b/translations/en.json
@@ -226,6 +226,10 @@
     "title": "This is a placeholder text marking the different between the new text and the old one",
     "value": "Original Description"
   },
+  "forbidden": {
+    "title": "when the user does not have access to see the linked ticket",
+    "value": "You are not authorized to view this linked ticket."
+  },
   "create_ticket": {
     "title": "empty",
     "value": "Create a ticket"

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -194,6 +194,10 @@ parts:
       title: "This is a placeholder text marking the different between the new text and the old one"
       value: "Original Description"
   - translation:
+      key: "txt.apps.linked_ticket_app.forbidden"
+      title: "when the user does not have access to see the linked ticket"
+      value: "You are not authorized to view this linked ticket."
+  - translation:
       key: "txt.apps.linked_ticket_app.create_ticket"
       title: "empty"
       value: "Create a ticket"


### PR DESCRIPTION
:koala:

If the user working on the parent ticket can't see the child ticket the app would allow them to create another linked ticket that overrides the current one.
Now they will see a message saying that there is already a linked ticket that they are not allowed to view, and they will not be able to create another linked ticket

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-516

### Risks
 - None