### PR TITLE
[OFFAPPS-611] Ensure HTML text in original description is sent correctly when creating child ticket

### DIFF
--- a/app.js
+++ b/app.js
@@ -428,9 +428,7 @@
     childTicketAttributes: function(){
       var params = {
         "subject": this.formSubject(),
-        "comment": {
-          "body": this.formDescription()
-        },
+        "comment": {},
         "custom_fields": [
           {
             id: this.ancestryFieldId(),
@@ -439,10 +437,7 @@
         ]
       };
 
-      if (this.ticket().comment().useRichText()){
-        delete params.comment.body;
-        params.comment.html_body = this.formDescription();
-      }
+      params.comment[this.ticket().comment().useRichText() ? 'html_body' : 'body'] = this.formDescription();
 
       _.extend(params,
                this.serializeRequesterAttributes(),

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@
       'autocompleteRequester.fail'      : 'genericAjaxFailure',
       'fetchGroups.fail'                : 'genericAjaxFailure',
       'fetchUsersFromGroup.fail'        : 'genericAjaxFailure',
+
       // DOM EVENTS
       'click .new-linked-ticket'        : 'displayForm',
       'click .create-linked-ticket'     : 'create',
@@ -355,7 +356,7 @@
     },
 
     copyDescription: function(){
-      var descriptionDelimiter = helpers.fmt("\n--- %@ --- \n", this.I18n.t("delimiter"));
+      var descriptionDelimiter = this.ticket().comment().useRichText() ? helpers.fmt("<br />--- %@ ---<br />", this.I18n.t("delimiter")) : helpers.fmt("\n--- %@ --- \n", this.I18n.t("delimiter"));
       var description = this.formDescription()
         .split(descriptionDelimiter);
 
@@ -427,11 +428,21 @@
     childTicketAttributes: function(){
       var params = {
         "subject": this.formSubject(),
-        "comment": { "body": this.formDescription() },
+        "comment": {
+          "body": this.formDescription()
+        },
         "custom_fields": [
-          { id: this.ancestryFieldId(), value: 'child_of:' + this.ticket().id() }
+          {
+            id: this.ancestryFieldId(),
+            value: 'child_of:' + this.ticket().id()
+          }
         ]
       };
+
+      if (this.ticket().comment().useRichText()){
+        delete params.comment.body;
+        params.comment.html_body = this.formDescription();
+      }
 
       _.extend(params,
                this.serializeRequesterAttributes(),


### PR DESCRIPTION
:koala:

check for this.ticket().comment.().useRichText() to ensure HTML is sent correctly when creating a ticket via the api

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-611

### Risks
 - None