### PR TITLE
Fixed a problem where line breaks were not being converted to HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -356,14 +356,16 @@
     },
 
     copyDescription: function(){
-      var descriptionDelimiter = this.ticket().comment().useRichText() ? helpers.fmt("<br />--- %@ ---<br />", this.I18n.t("delimiter")) : helpers.fmt("\n--- %@ --- \n", this.I18n.t("delimiter"));
+      var useRichText = this.ticket().comment().useRichText();
+      var descriptionDelimiter = useRichText ? helpers.fmt("<br />--- %@ ---<br />", this.I18n.t("delimiter")) : helpers.fmt("\n--- %@ --- \n", this.I18n.t("delimiter"));
       var description = this.formDescription()
         .split(descriptionDelimiter);
+     var ticketDescription = useRichText ? this.convertLineBreaksToHtml(this.ticket().description()) : this.ticket().description();
 
       var ret = description[0];
 
       if (description.length === 1)
-        ret += descriptionDelimiter + this.ticket().description();
+        ret += descriptionDelimiter + ticketDescription;
 
       this.formDescription(ret);
     },
@@ -594,6 +596,9 @@
         return;
 
       return this.childRegex.exec(this.ancestryValue())[1];
+    },
+    convertLineBreaksToHtml: function(strToConvert){
+      return strToConvert.replace(/\n/g, "<br />");
     }
   };
 }());

--- a/app.js
+++ b/app.js
@@ -357,14 +357,15 @@
 
     copyDescription: function(){
       var useRichText = this.ticket().comment().useRichText();
-      var descriptionDelimiter = useRichText ? helpers.fmt("<br />--- %@ ---<br />", this.I18n.t("delimiter")) : helpers.fmt("\n--- %@ --- \n", this.I18n.t("delimiter"));
-      var description = this.formDescription()
+      var newLine = useRichText ? '<br />' : '\n';
+      var descriptionDelimiter = helpers.fmt(newLine + "--- %@ ---" + newLine, this.I18n.t("delimiter"));
+      var currentDescription = this.formDescription()
         .split(descriptionDelimiter);
      var ticketDescription = useRichText ? this.convertLineBreaksToHtml(this.ticket().description()) : this.ticket().description();
 
-      var ret = description[0];
+      var ret = currentDescription[0];
 
-      if (description.length === 1)
+      if (currentDescription.length === 1)
         ret += descriptionDelimiter + ticketDescription;
 
       this.formDescription(ret);

--- a/app.js
+++ b/app.js
@@ -357,15 +357,16 @@
 
     copyDescription: function(){
       var useRichText = this.ticket().comment().useRichText();
+      var ticketDescription = this.ticket().description();
       var newLine = useRichText ? '<br />' : '\n';
       var descriptionDelimiter = helpers.fmt(newLine + "--- %@ ---" + newLine, this.I18n.t("delimiter"));
-      var currentDescription = this.formDescription()
+      var formDescription = this.formDescription()
         .split(descriptionDelimiter);
-     var ticketDescription = useRichText ? this.convertLineBreaksToHtml(this.ticket().description()) : this.ticket().description();
+     var ticketDescription = useRichText ? this.convertLineBreaksToHtml(ticketDescription) : ticketDescription;
 
-      var ret = currentDescription[0];
+      var ret = formDescription[0];
 
-      if (currentDescription.length === 1)
+      if (formDescription.length === 1)
         ret += descriptionDelimiter + ticketDescription;
 
       this.formDescription(ret);


### PR DESCRIPTION
:koala:

If a customer creates a linked ticket from a parent ticket that was created using text/markdown and they have since upgraded to WYSIWYG the line breaks from the original text ticket were not being converted to HTML and hence were being ignored.

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-611

### Risks
 - None