### PR TITLE
[OFFAPPS-611] Changed behaviour of copyDescription to call out to REST API to get d…

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,9 +83,9 @@
           type: 'GET'
         };
       },
-      fetchComments: function(ticket_id){
+      fetchComments: function(ticketId){
         return {
-          url: '/api/v2/tickets/' + ticket_id + '/comments.json',
+          url: '/api/v2/tickets/' + ticketId + '/comments.json?per_page=1',
           type: 'GET'
         };
       },
@@ -365,25 +365,28 @@
     },
 
     copyDescription: function(){
-      //calling out to comments endpoint here because the lotus model always returns HTML
-      //for the this.ticket().comments()[0].value and we may need MD or HTML.
+      this.spinnerOn();
+      this.disableSubmit();
+
       this.ajax('fetchComments', this.ticket().id()).then(function(data) {
         var useRichText = this.ticket().comment().useRichText();
         var ticketDescription = data.comments[0];
         var newTicketContent = useRichText ? ticketDescription.html_body : ticketDescription.body;
         var newLine = useRichText ? '<br />' : '\n';
         var descriptionDelimiter = helpers.fmt(newLine + "--- %@ ---" + newLine, this.I18n.t("delimiter"));
-        var formDescription = this.formDescription()
-          .split(descriptionDelimiter);
-        //newTicketContent = useRichText ? this.convertLineBreaksToHtml(newTicketContent) : newTicketContent;
+        var formDescription = this.formDescription().split(descriptionDelimiter);
 
         var ret = formDescription[0];
 
-        if (formDescription.length === 1)
+        if (formDescription.length === 1) {
           ret += descriptionDelimiter + newTicketContent;
+        }
 
         this.formDescription(ret);
-      });
+
+        this.spinnerOff();
+        this.enableSubmit();
+      }.bind(this));
     },
 
     bindAutocompleteOnRequesterEmail: function(){


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Changed behaviour of `copyDescription` to call out to REST API to get description. The reason for doing this is that `this.ticket().comments()[0].value()` will always return HTML but we need to ensure we get the correct mark-up for the users setting (Markdown or Rich text).

### References
* JIRA: https://zendesk.atlassian.net/browse/OFFAPPS-611

### Risks
* Does it work across browsers (including IE!)?
  * This change only affects the way data is retrieved.
* Are there any performance implications?
  * A small performance hit because we are now calling out to the REST API instead of using the data API.