### PR TITLE
Display user name in requester dropdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -398,7 +398,7 @@
         source: function(request, response) {
           self.ajax('autocompleteRequester', request.term).done(function(data){
             response(_.map(data.users, function(user){
-              return {"label": user.email, "value": user.email};
+              return {"label": user.name + " - " + user.email, "value": user.email};
             }));
           });
         },


### PR DESCRIPTION
Its useful when you have typed in just the first name in the field and you have multiple email options but you don't know which user they belong to. Right now you have to type the full user name to get only one result in dropdown.
